### PR TITLE
Remove `qwen3-235b-a22b-thinking-2507` from support `developer` role

### DIFF
--- a/ccproxy/config.py
+++ b/ccproxy/config.py
@@ -44,7 +44,6 @@ SUPPORT_DEVELOPER_MESSAGE_MODELS: FrozenSet[str] = frozenset({
     "gpt-5-mini",
     "gpt-5-2025-08-07",
     "gpt-5",
-    "qwen/qwen3-235b-a22b-thinking-2507",
 })
 
 # Models that are in the top tier of the OpenAI API


### PR DESCRIPTION
### **PR Type**
Configuration

___

### **PR Description**
- Removed `qwen/qwen3-235b-a22b-thinking-2507` from `SUPPORT_DEVELOPER_MESSAGE_MODELS`.

- Maintained the model in other supported model sets (`SUPPORT_REASONING_EFFORT_MODELS`, `NO_SUPPORT_TEMPERATURE_MODELS`).
