### PR TITLE
`v1.0.4`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "httpx[http2]>=0.28.1",
     "pydantic>=2.11.7",
     "python-dotenv>=1.1.1",
-    "openai>=1.100.0",
+    "openai>=1.100.1",
     "pydantic-settings>=2.10.1",
     "tiktoken>=0.11.0",
     "yarl==1.20.1",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@ fastapi==0.116.1
 uvicorn[standard]==0.35.0
 
 # OpenAI client
-openai==1.100.0
+openai==1.100.1
 
 # Data validation
 pydantic==2.11.7
@@ -15,7 +15,7 @@ pydantic-settings==2.10.1
 # Token counting
 tiktoken==0.11.0
 tqdm==4.67.1
-typer==0.16.0
+typer==0.16.1
 typing-extensions==4.14.1
 typing-inspection==0.4.1
 urllib3==2.5.0
@@ -40,4 +40,4 @@ six==1.17.0
 
 pytest==8.4.1
 pytest-asyncio==1.1.0
-ruff==0.12.8
+ruff==0.12.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ fastapi==0.116.1
 uvicorn[standard]==0.35.0
 
 # OpenAI client
-openai==1.100.0
+openai==1.100.1
 
 # Data validation
 pydantic==2.11.7
@@ -15,7 +15,7 @@ pydantic-settings==2.10.1
 # Token counting
 tiktoken==0.11.0
 tqdm==4.67.1
-typer==0.16.0
+typer==0.16.1
 typing-extensions==4.14.1
 typing-inspection==0.4.1
 urllib3==2.5.0


### PR DESCRIPTION
### **PR Type**
Dependencies, Configuration

___

### **PR Description**
- Updated `openai` dependency from `1.99.9` to `1.100.1` across all configuration files.

- Bumped project version from `1.0.3` to `1.0.4` in `pyproject.toml`.

- Updated `ruff` from `0.12.8` to `0.12.9` and `typer` from `0.16.0` to `0.16.1`.

- Updated `pytest-sugar` from `1.0.0` to `1.1.0` in development dependencies.
