### PR TITLE
JSON logging automatically omits null values for cleaner output

### DIFF
--- a/ccproxy/CLAUDE.md
+++ b/ccproxy/CLAUDE.md
@@ -2,9 +2,11 @@
 
 Scope: Python package root for CCProxy.
 
-Guidelines
+Guidelines:
+
 - Import via relative package paths; avoid global singletons
 - Construct apps with ccproxy.interfaces.http.app.create_app(Settings)
 - Keep modules small and dependency direction inward (application <- interfaces)
 - Do not log secrets; use ccproxy.logging helpers
 - Preserve UTF-8 when handling bytes/strings
+- JSON logging automatically omits null values for cleaner output


### PR DESCRIPTION
### **PR Type**
Enhancement, Refactoring

___

### **PR Description**
- Enhanced JSON logging by automatically filtering out null values for cleaner output

- Updated `_sanitize_for_json` function to remove null values from dictionaries and lists

- Modified both `JSONFormatter` and `ConsoleJSONFormatter` to benefit from null filtering

- Added documentation note about null value omission in `CLAUDE.md`
