### PR TITLE
Use model `qwen/qwen3-coder-480b-a35b-07-25` for small model

### DIFF
--- a/.env.openrouter
+++ b/.env.openrouter
@@ -1,5 +1,5 @@
 OPENAI_API_KEY=sk-or-v1-xxx-58b
 BIG_MODEL_NAME=x-ai/grok-code-fast-1
-SMALL_MODEL_NAME=qwen/qwen3-coder
+SMALL_MODEL_NAME=qwen/qwen3-coder-480b-a35b-07-25
 LOG_LEVEL=DEBUG
 OPENAI_BASE_URL=https://openrouter.ai/api/v1


### PR DESCRIPTION
### **PR Type**
Configuration

___

### **PR Description**
- Updated `SMALL_MODEL_NAME` from `qwen/qwen3-coder` to `qwen/qwen3-coder-480b-a35b-07-25`

- Modified environment configuration file `.env.openrouter`
