### PR TITLE
Print out `uv` and `ruff` version for shell scripts

### DIFF
--- a/run-ccproxy.sh
+++ b/run-ccproxy.sh
@@ -37,6 +37,9 @@ if ! command_exists uv; then
     exit 1
 fi
 
+# Print uv version
+print_info "uv version: $(uv --version)"
+
 # Check if Python 3 is available through uv
 print_info "Checking Python availability via uv..."
 if ! uv python list | grep -q "python"; then
@@ -222,10 +225,12 @@ if [ -f "requirements.txt" ] || [ -f "pyproject.toml" ]; then
     print_info "Installing/syncing dependencies via uv..."
     uv sync --dev
     print_success "Dependencies synchronized successfully"
+    print_info "uv version after sync: $(uv --version)"
 else
     print_info "No requirements.txt or pyproject.toml found - will install minimal dependencies"
     # Ensure basic dependencies are available
     uv add fastapi uvicorn openai pydantic tiktoken httpx gunicorn --dev
+    print_info "uv version after add: $(uv --version)"
 fi
 
 # Function to extract version from pyproject.toml

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -39,7 +39,8 @@ check_pytest() {
     fi
 
     echo -e "${GREEN}✅ pytest is available via uv${NC}"
-    echo -e "${CYAN}Version: $(uv run pytest --version)${NC}"
+    echo -e "${CYAN}uv version: $(uv --version)${NC}"
+    echo -e "${CYAN}pytest version: $(uv run pytest --version)${NC}"
 }
 
 # Function to find test files

--- a/start-lint.sh
+++ b/start-lint.sh
@@ -39,7 +39,8 @@ check_ruff() {
     fi
 
     echo -e "${GREEN}✅ ruff is available via uv${NC}"
-    echo -e "${CYAN}Version: $(uv run --with ruff ruff --version)${NC}"
+    echo -e "${CYAN}uv version: $(uv --version)${NC}"
+    echo -e "${CYAN}ruff version: $(uv run --with ruff ruff --version)${NC}"
 }
 
 # Function to find Python files
@@ -223,7 +224,8 @@ install_ruff() {
     uv add --dev ruff
 
     echo -e "${GREEN}✅ ruff installation completed via uv${NC}"
-    echo -e "${CYAN}Version: $(uv run --with ruff ruff --version)${NC}"
+    echo -e "${CYAN}uv version: $(uv --version)${NC}"
+    echo -e "${CYAN}ruff version: $(uv run --with ruff ruff --version)${NC}"
 }
 
 # Function to list files


### PR DESCRIPTION
### **PR Type**
`Enhancement`

___

### **PR Description**
- Added version printing for `uv` and `ruff` in shell scripts.

- Enhanced `run-ccproxy.sh` to display `uv` version before and after dependency operations.

- Updated `run-tests.sh` to show both `uv` and `pytest` versions during test setup.

- Modified `start-lint.sh` to display `uv` and `ruff` versions for linting operations.
