### PR TITLE
Enable `http2` for `DefaultAioHttpClient`

### DIFF
--- a/ccproxy/infrastructure/providers/http_client_factory.py
+++ b/ccproxy/infrastructure/providers/http_client_factory.py
@@ -104,7 +104,7 @@ class HttpClientFactory:
         # Try to use aiohttp client if available, fallback to httpx
         try:
             # Try to create aiohttp client - will fail if aiohttp extra not installed
-            client = DefaultAioHttpClient()
+            client = DefaultAioHttpClient(http2=True)
             logging.info("Using DefaultAioHttpClient for production deployment")
             return client
         except (ImportError, RuntimeError):


### PR DESCRIPTION
### **PR Type**
`Enhancement`, `Performance`

___

### **PR Description**
- Enabled HTTP/2 support for `DefaultAioHttpClient` in production deployments.

- Maintained HTTP/2 support for `DefaultAsyncHttpxClient` in both local and production environments.

- Improved connection efficiency and performance through HTTP/2 protocol usage.

- Preserved fallback mechanisms for environments without HTTP/2 dependencies.
