### PR TITLE
`fastapi>=0.118.1`

### DIFF
--- a/ccproxy/config.py
+++ b/ccproxy/config.py
@@ -45,7 +45,7 @@ class Settings(BaseSettings):
     )
     referer_url: str = "http://localhost:11434/claude_proxy"
     app_name: str = "CCProxy"
-    app_version: str = "1.1.0"
+    app_version: str = "1.4.1"
     log_level: str = Field(default="INFO", validation_alias=AliasChoices("LOG_LEVEL"))
     log_file_path: Optional[str] = "log.jsonl"
     error_log_file_path: Optional[str] = Field(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
     {name = "CCWorkforce Engineers"}
 ]
 dependencies = [
-    "fastapi[standard]>=0.118.0",
+    "fastapi[standard]>=0.118.1",
     "uvicorn>=0.37.0",
     "httpx[http2]>=0.28.1",
     "pydantic>=2.12.0",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@
 # Pinned versions for reproducible builds
 
 # FastAPI framework
-fastapi>=0.118.0
+fastapi>=0.118.1
 uvicorn[standard]>=0.37.0
 orjson>=3.11.3
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 # Pinned versions for reproducible builds
 
 # FastAPI framework
-fastapi>=0.118.0
+fastapi>=0.118.1
 uvicorn[standard]>=0.37.0
 orjson>=3.11.3
 

--- a/uv.lock
+++ b/uv.lock
@@ -212,7 +212,7 @@ requires-dist = [
     { name = "aiohttp", marker = "extra == 'aiohttp'", specifier = ">=3.13.0" },
     { name = "anyio", specifier = ">=4.11.0" },
     { name = "asyncer", specifier = ">=0.0.9" },
-    { name = "fastapi", extras = ["standard"], specifier = ">=0.118.0" },
+    { name = "fastapi", extras = ["standard"], specifier = ">=0.118.1" },
     { name = "httpx", extras = ["http2"], specifier = ">=0.28.1" },
     { name = "httpx-aiohttp", specifier = ">=0.1.8" },
     { name = "openai", extras = ["aiohttp"], specifier = ">=2.2.0" },
@@ -447,16 +447,16 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.118.0"
+version = "0.118.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "starlette" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/28/3c/2b9345a6504e4055eaa490e0b41c10e338ad61d9aeaae41d97807873cdf2/fastapi-0.118.0.tar.gz", hash = "sha256:5e81654d98c4d2f53790a7d32d25a7353b30c81441be7d0958a26b5d761fa1c8", size = 310536, upload-time = "2025-09-29T03:37:23.126Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/1b/6cbc5bc6d7a07a506c2275d443e4517adb4e02ab42e0a6486568e1749896/fastapi-0.118.1.tar.gz", hash = "sha256:063f9d4ff5bcdfd1ef6e4e6b44ed5fb5f4bf370b39cdce1c9aed22413c371cfe", size = 311185, upload-time = "2025-10-08T09:07:24.199Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/20/54e2bdaad22ca91a59455251998d43094d5c3d3567c52c7c04774b3f43f2/fastapi-0.118.0-py3-none-any.whl", hash = "sha256:705137a61e2ef71019d2445b123aa8845bd97273c395b744d5a7dfe559056855", size = 97694, upload-time = "2025-09-29T03:37:21.338Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/29/9bf43b2fe09854a4c743eed5ef9b6a84bab39b05bfd46aea7ce6c7bf97f1/fastapi-0.118.1-py3-none-any.whl", hash = "sha256:be88c15c995464d14d2be1d7059860551aeffb9df889688bcea7050c9635badf", size = 97933, upload-time = "2025-10-08T09:07:22.003Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
### **PR Type**
`Dependencies`, `Configuration`

___

### **PR Description**
- Updated `fastapi` dependency from `0.118.0` to `0.118.1` across all dependency files.

- Bumped application version from `1.1.0` to `1.4.1` in configuration settings.

- Maintained consistency across `pyproject.toml`, `requirements.txt`, and `requirements-dev.txt`.

- No breaking changes introduced in this minor version update.
